### PR TITLE
SE-2411 Ensures that the drop-down user menu has a background color

### DIFF
--- a/lms/static/sass/theme-overrides.scss
+++ b/lms/static/sass/theme-overrides.scss
@@ -37,8 +37,12 @@
     .nav-item a {
       color: $link-color;
     }
-    .dropdown-user-menu .dropdown-item a {
-      color: $link-color;
+    .dropdown-user-menu {
+      background-color: $header-bg;
+
+      .dropdown-item a {
+        color: $link-color;
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes issue where the user drop-down menu shows up as transparent.

**Screenshots**

Before:

![bad menu](https://user-images.githubusercontent.com/7556571/77722668-54ba4c00-703e-11ea-8a07-fcd9ff17df38.png)

After:

![good menu](https://user-images.githubusercontent.com/7556571/77722675-5ab02d00-703e-11ea-8be7-f9775bf5493e.png)

**Testing instructions**

This theme branch is deployed on the client's Appserver 3.  Login, and verify that the user menu is fixed as shown above.

**Reviewer**
- [x] @swalladge 