### PR TITLE
[BB-2445] Fix the issue setting the link color for button text

### DIFF
--- a/lms/static/sass/theme-overrides.scss
+++ b/lms/static/sass/theme-overrides.scss
@@ -63,7 +63,7 @@ a:not(.btn), a:not(.btn):hover, a:not(.btn):focus, a:visited:not(.btn):hover, a:
             }
         }
     }
-    .main .nav-tab a, .secondary .nav-item a, .secondary .nav-item .toggle-user-dropdown {
+    .main .nav-tab a, .secondary .nav-item a:not(.btn), .secondary .nav-item .toggle-user-dropdown {
         // Set the color of the dropdown arrow of the user dropdowm menu
         color: $link-color !important;
     }
@@ -372,4 +372,4 @@ a:not(.btn), a:not(.btn):hover, a:not(.btn):focus, a:visited:not(.btn):hover, a:
       color: $link-color !important;
     }
   }
-} 
+}


### PR DESCRIPTION
This fixes the issue where the link color was set as the text color for all the buttons.

**Testing instructions**:
* Clone this repository in a directory accessible inside the LMS devstack. The `src` folder which is at the same level as the `edx-platform`, `devstack` directories is a good candidate for this as it is mounted in the LMS devstack at `/edx/src`.
* Check out this PR branch.
* Create a `common-variables.scss` file in the `<repo dir>/lms/static/sass` directory with the following contents.
  ```sass
  $footer-bg: #FFFFFF;
  $header-bg: #FFFFFF;
  $link-color: orange;
  $main-color: #126F9A;
  $btn-primary-bg: #126F9A;
  $btn-secondary-bg: #FFFFFF;
  $btn-primary-color: #FFFFFF;
  $btn-secondary-color: #126F9A;
  $user-dropdown-color: #bd10e0;
  $btn-primary-hover-bg: #FFFFFF;
  $btn-secondary-hover-bg: #126F9A;
  $btn-primary-hover-color: #126F9A;
  $btn-primary-border-color: #126F9A;
  $btn-secondary-hover-color: #FFFFFF;
  $btn-secondary-border-color: #126F9A;
  $home-page-hero-title-color: #313131;
  $home-page-hero-subtitle-color: #646464;
  $btn-primary-hover-border-color: #126F9A;
  $btn-secondary-hover-border-color: #FFFFFF;
  ```
* Create `_lms-overrides.scss` in the same directory with the following content
  ```scss
  @import 'common-variables';
  ```
* Create `partials/lms/theme/_variables-v1.scss` (relative to the same directory) with the following content.
  ```scss
  @import '../common-variables';
  @import 'lms/static/sass/partials/lms/theme/variables-v1';
  ```
* In the `/edx/app/edxapp/lms.env.json` file inside the LMS devstack, enable comprehensive theming (set `ENABLE_COMPREHENSIVE_THEMING: true`), add the parent directory of the cloned repo to the `COMPREHENSIVE_THEME_DIRS` array.
* Set the value of the `DEFAULT_SITE_THEME` variable to the name of the cloned theme repository, say `edx-simple-theme`.
* Save the file and close it.
* Inside the LMS devstack, from the `/edx/app/edxapp/edx-platform` directory, run `paver update_assets lms`. Verify that the static assets are compiled and collected without any errors.
* Restart the LMS container to apply the changes made to `lms.env.json`.
* Open the LMS homepage and verify that the register and sign-in buttons have the default edX colors applied and that the link color (orange in this case) is not set as the link text color.
* For comparison, switch to the master branch of the repository, compile the theme again by running `paver update_assets lms` from the LMS shell and verify that the link color is set as the text color of the buttons.
* You can also see the fix deployed on [this instance](https://testxavier2.opencraft.hosting/).
