### PR TITLE
[SE-2361] Fix help link styling in header

### DIFF
--- a/lms/static/sass/theme-overrides.scss
+++ b/lms/static/sass/theme-overrides.scss
@@ -40,7 +40,7 @@ a:not(.btn), a:not(.btn):hover, a:not(.btn):focus, a:visited:not(.btn):hover, a:
   .nav-links {
     @if variable-exists(main-nav-link-color) {
       // Set the color of the links in the dashboard
-      .main .nav-tab a, .secondary .nav-item a, .secondary .nav-item a span, .toggle-user-dropdown span {
+      .main .nav-tab a, .secondary .nav-item a:not(.help-link), .secondary .nav-item a span, .toggle-user-dropdown span {
         color: $main-nav-link-color !important;
       }
     }

--- a/lms/static/sass/theme-overrides.scss
+++ b/lms/static/sass/theme-overrides.scss
@@ -13,7 +13,7 @@
 }
 
 // Set the default color of links
-a:not(.btn), a:not(.btn):hover, a:not(.btn):focus, a:visited:not(.btn):hover, a:visited:not(.btn):focus {
+a:not(.btn), a:not(.btn):hover, a:not(.btn):focus, a:visited:not(.btn):hover, a:visited:not(.btn):focus, a:not(.help-link) {
   color: $link-color;
 }
 
@@ -40,7 +40,7 @@ a:not(.btn), a:not(.btn):hover, a:not(.btn):focus, a:visited:not(.btn):hover, a:
   .nav-links {
     @if variable-exists(main-nav-link-color) {
       // Set the color of the links in the dashboard
-      .main .nav-tab a, .secondary .nav-item a:not(.help-link), .secondary .nav-item a span, .toggle-user-dropdown span {
+      .main .nav-tab a, .secondary .nav-item a, .secondary .nav-item a span, .toggle-user-dropdown span {
         color: $main-nav-link-color !important;
       }
     }
@@ -68,7 +68,7 @@ a:not(.btn), a:not(.btn):hover, a:not(.btn):focus, a:visited:not(.btn):hover, a:
       }
     }
   }
-  .main .nav-tab a, .secondary .nav-item a:not(.btn), .secondary .nav-item .toggle-user-dropdown {
+  .main .nav-tab a, .secondary .nav-item a:not(.btn):not(.help-link), .secondary .nav-item .toggle-user-dropdown {
     // Set the color of the dropdown arrow of the user dropdowm menu
     color: $link-color !important;
   }


### PR DESCRIPTION
This PR prevents the link styling being applied to the Help link in the header.

**Testing Instructions:**
- Test on the instance created for SE-2361 (link TBD)