### PR TITLE
SE-3327 Remove lms-main-v2 / lms-discussion-main templates override

### DIFF
--- a/lms/static/sass/discussion/lms-discussion-main.scss
+++ b/lms/static/sass/discussion/lms-discussion-main.scss
@@ -1,2 +1,0 @@
-@import 'lms/static/sass/discussion/lms-discussion-main';
-@import '../theme-colors';

--- a/lms/static/sass/lms-main-v2.scss
+++ b/lms/static/sass/lms-main-v2.scss
@@ -1,3 +1,0 @@
-@import 'lms/static/sass/lms-main-v2';
-
-@import 'theme-overrides';


### PR DESCRIPTION
**WARNING**: do not merge until we upgrade everything that uses this to Koa.  This fixes issues present on master at time of writing, but we use master of this repo for current maintained instances (ie. latest edx platform release).

Note that there may also be other issues with this theme and Koa; see https://github.com/edx/configuration/pull/5837 for related fixes (edx/configuration simple-theme role has similarities to this repo theme). 

cf. edx-platform  https://github.com/edx/edx-platform/pull/24624

This should fix this error:

```
sass.CompileError: b"Error: File to import not found or unreadable: lms/static/sass/lms-main-v2
    Parent style sheet: /edx/var/edxapp/themes/simple-theme/lms/static/sass/lms-main-v2.scss
    on line 1 of ../../../var/edxapp/themes/simple-theme/lms/static/sass/lms-main-v2.scss
    >> @import 'lms/static/sass/lms-main-v2';
       ^
```

**Test instructions**:

- launch an instance with the comprehensive theming enabled and pointed at this branch
- verify that provisioning succeeds.


**Reviewers**:

- [ ] @bradenmacdonald 
- [x] @lgp171188 