### PR TITLE
[BB-3340] Change theme-colors function call to theme-color

### DIFF
--- a/lms/static/sass/theme-colors.scss
+++ b/lms/static/sass/theme-colors.scss
@@ -6,16 +6,16 @@ $link-color: #126f9a !default;
 $header-bg: #ffffff !default;
 $footer-bg: #ffffff !default;
 
-$btn-primary-bg: theme-colors("primary") !default;
-$btn-primary-color: theme-colors("inverse") !default;
-$btn-primary-border-color: theme-colors("primary") !default;
-$btn-primary-hover-bg: theme-colors("primary") !default;
-$btn-primary-hover-color: theme-colors("inverse") !default;
-$btn-primary-hover-border-color: theme-colors("primary") !default;
+$btn-primary-bg: theme-color("primary") !default;
+$btn-primary-color: theme-color("inverse") !default;
+$btn-primary-border-color: theme-color("primary") !default;
+$btn-primary-hover-bg: theme-color("primary") !default;
+$btn-primary-hover-color: theme-color("inverse") !default;
+$btn-primary-hover-border-color: theme-color("primary") !default;
 
-$btn-secondary-bg: theme-colors("primary") !default;
-$btn-secondary-color: theme-colors("inverse") !default;
-$btn-secondary-border-color: theme-colors("primary") !default;
-$btn-secondary-hover-bg: theme-colors("primary") !default;
-$btn-secondary-hover-color: theme-colors("inverse") !default;
-$btn-secondary-hover-border-color: theme-colors("primary") !default;
+$btn-secondary-bg: theme-color("primary") !default;
+$btn-secondary-color: theme-color("inverse") !default;
+$btn-secondary-border-color: theme-color("primary") !default;
+$btn-secondary-hover-bg: theme-color("primary") !default;
+$btn-secondary-hover-color: theme-color("inverse") !default;
+$btn-secondary-hover-border-color: theme-color("primary") !default;


### PR DESCRIPTION
This PR changes all occurrence of ``theme-colors`` function call to ``theme-color`` function call. As there is no such function named ``theme-colors``. Before this PR, compiled versions of ``lms-main-v1.css`` and ``lms-main-v2.css`` had invalid property value for all color-related CSS properties.

**JIRA tickets**: This issue found while working on the following ticket -
https://tasks.opencraft.com/browse/BB-3091

~~**Discussions**: ~~

**Dependencies**: None

~~**Screenshots**:~~

~~**Sandbox URL**:~~

**Merge deadline**: "None" 

**Testing instructions**:

1. Install this theme on a devstack
2. Override value of ``$theme-colors`` map. ex - https://getbootstrap.com/docs/4.0/getting-started/theming/#modify-map
3. After compiling sass overridden theme colors should be reflected on ``lms-main-v1.css`` and ``lms-main-v2.css``

**Author notes and concerns**:
N/A

**Reviewers**
- [ ] @giovannicimolin 
- [ ] @lgp171188 
~~**Settings**~~