### PR TITLE
fix: [BB-4533] Fix some inconsistency issues encountered with lms mfe

### DIFF
--- a/common/_overrides.scss
+++ b/common/_overrides.scss
@@ -3,24 +3,36 @@
   color: $color !important;
   border: 1px solid $border-color !important;
 
+  span {
+    color: $color !important;
+  }
+
   &:hover {
     background-color: $hover-bg !important;
     color: $hover-color !important;
     border-color: $hover-border-color !important;
+
+    span {
+      color: $hover-color !important;
+    }
   }
 }
 
 // Set the default color of links
-a:not(.btn),
+a:not(.btn, .help-link),
 a:not(.btn):hover,
 a:not(.btn):focus,
 a:visited:not(.btn):hover,
-a:visited:not(.btn):focus,
-a:not(.help-link) {
+a:visited:not(.btn):focus {
   color: $link-color;
 }
 
-.btn-primary {
+.btn-primary,
+.btn-brand {
   // Set the styles for the primary button
   @include btn-styles($btn-primary-bg, $btn-primary-color, $btn-primary-border-color, $btn-primary-hover-bg, $btn-primary-hover-color, $btn-primary-hover-border-color);
+}
+
+.btn-outline-primary {
+  @include btn-styles($btn-secondary-bg, $btn-secondary-color, $btn-secondary-border-color, $btn-secondary-hover-bg, $btn-secondary-hover-color, $btn-secondary-hover-border-color);
 }

--- a/lms/static/sass/theme-overrides.scss
+++ b/lms/static/sass/theme-overrides.scss
@@ -401,7 +401,6 @@
 }
 
 // For the discussion home page button and the embedded discussion block
-.btn-outline-primary,
 .discussion-module .discussion-show.btn {
   @include btn-styles($btn-secondary-bg, $btn-secondary-color, $btn-secondary-border-color, $btn-secondary-hover-bg, $btn-secondary-hover-color, $btn-secondary-hover-border-color);
 }

--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -120,3 +120,24 @@ footer.footer {
     }
   }
 }
+
+// Set color for course nav bar in Learning MFE
+.course-tabs-navigation a.nav-link {
+  @if variable-exists(course-nav-menu-color) {
+    &:focus,
+    &:hover,
+    &.active {
+      color: $course-nav-menu-color;
+    }
+  }
+
+  @if variable-exists(course-nav-menu-border-bottom-color) {
+    &.active {
+      border-bottom-color: $course-nav-menu-border-bottom-color;
+    }
+  }
+}
+
+.btn-outline-secondary {
+  @include btn-styles($btn-secondary-bg, $btn-secondary-color, $btn-secondary-border-color, $btn-secondary-hover-bg, $btn-secondary-hover-color, $btn-secondary-hover-border-color);
+}


### PR DESCRIPTION
**Summary**
This PR fix some "inconsistencies" found between mfe style and legacy view when applying simple theme

**Tickets**
https://gitlab.com/opencraft/dev/branding-and-theming/-/issues/8
https://tasks.opencraft.com/browse/BB-4533

**Details of change**
When edx-simple-simple theme is applied to learning mfe, some issues were present:

- Dropdown button class btn-outline-primary should use btn-secondary-color:
<img width="1569" alt="Screen Shot 2021-08-23 at 17 27 43" src="https://user-images.githubusercontent.com/13887866/130657547-a0520604-4dcd-4683-89dd-b3bf74af7588.png">
<img width="1569" alt="Screen Shot 2021-08-23 at 17 28 41" src="https://user-images.githubusercontent.com/13887866/130659855-d874466a-5232-4c89-a5dc-db31df17ab5f.png">

After change:
<img width="1566" alt="Screen Shot 2021-08-23 at 17 32 19" src="https://user-images.githubusercontent.com/13887866/130658241-ffc2c659-b33b-4d2e-8467-3bd6d67180df.png">
<img width="1566" alt="Screen Shot 2021-08-23 at 17 33 12" src="https://user-images.githubusercontent.com/13887866/130659794-9e55b1ae-dedb-4e33-b975-169a3b4d2b8b.png">


- Links with btn class used the default $link-color and it was intended in `common/_overrides.scss` with `a:not(btn)` selector that it should not use it
<img width="1569" alt="Screen Shot 2021-08-23 at 17 27 59" src="https://user-images.githubusercontent.com/13887866/130658613-4fb72192-8c53-455f-bccd-4bc79cb09f21.png">
<img width="1569" alt="Screen Shot 2021-08-23 at 17 30 22" src="https://user-images.githubusercontent.com/13887866/130658674-2319bfa2-c7f0-4e92-b54b-04c4686b95bb.png">
After change:
<img width="1566" alt="Screen Shot 2021-08-23 at 17 32 28" src="https://user-images.githubusercontent.com/13887866/130658839-4d97ff2b-58cf-47f8-83bf-75b1d77b1d9b.png">
<img width="1302" alt="Screen Shot 2021-08-24 at 12 00 30" src="https://user-images.githubusercontent.com/13887866/130658803-f0e093a7-8186-406f-a03f-eba8e83abb1d.png">

- Navbar style did not use colors defined in $course-nav-menu-color and $course-nav-menu-border-bottom-color. Also visited tabs were colored with default $link-color when they are already visited
<img width="1569" alt="Screen Shot 2021-08-23 at 17 28 15" src="https://user-images.githubusercontent.com/13887866/130659328-22fa36dc-58d2-49d6-ab9b-33c7a5d2d280.png">
<img width="1569" alt="Screen Shot 2021-08-23 at 17 28 19" src="https://user-images.githubusercontent.com/13887866/130659336-bf120538-e9ef-4d18-b1e1-3930d0b6d621.png">
After change:
<img width="1566" alt="Screen Shot 2021-08-23 at 17 32 44" src="https://user-images.githubusercontent.com/13887866/130659471-00a734a8-e734-40f0-b017-dc79e04f1bec.png">

- Brand button, in the legacy experience it used the btn-primary style, I think it should be the same for the class .btn-brand, otherwise it uses a default background purple color and link-color
<img width="1569" alt="Screen Shot 2021-08-23 at 17 28 33" src="https://user-images.githubusercontent.com/13887866/130659702-5b12ef9e-9f09-47ee-bb92-325732f8e416.png">
After change:
<img width="1566" alt="Screen Shot 2021-08-23 at 17 33 00" src="https://user-images.githubusercontent.com/13887866/130659737-7630ade4-bbe6-4ef5-864f-8b938a3a1eac.png">

**Notes**
There are things that should apply other colors like the course breadcrumbs, they should be colored with the default $link-color, but these have a class that explicitly colour them(text-primary-500, etc.) and this is present in other elements as well. Maybe we should create an issue to remove this classes in the learning MFE, so it is more customizable



**Test Steps**
- Install the theme in the learning MFE on a devstack as a brand package
- Customize the theme by defining theme variables in common-variables.scss
- Go to the different parts of the learning MFE, like course home or course content, and check that the defined styles are correctly applied, you can take as reference the ones fixed on this PR, also you can compare the learning MFE  with the Legacy Experience and these should be similar.