### PR TITLE
[SE-5480] Change default footer background color to white.

### DIFF
--- a/common/_variables.scss
+++ b/common/_variables.scss
@@ -2,7 +2,7 @@
 $main-color: #ff8000 !default;
 $link-color: #126f9a !default;
 $header-bg: #fff !default;
-$footer-bg: #882211 !default;
+$footer-bg: #fff !default;
 
 $btn-primary-bg: theme-color("primary") !default;
 $btn-primary-color: theme-color("inverse") !default;


### PR DESCRIPTION
I'm guessing the weird red default was set up for testing and we never noticed because Ocim is overriding the default value with white.

Grove doesn't (yet) set any default values on its own so it's using the theme's defaults and we want the footer to look normal.

**Test instructions**:

Verify that the tutor14 instance [was deployed successfully](https://gitlab.com/opencraft/ops/grove-stage-digitalocean/-/pipelines/577722594) using [this branch](https://gitlab.com/opencraft/ops/grove-stage-digitalocean/-/commit/374030b7119d77b206b3e7dd4931987d756971a1); then verify that the footer has a white background color.