### PR TITLE
refactor: target lms headers specifically

### DIFF
--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -1,13 +1,8 @@
 @import "../common/overrides";
 
-header {
+header.learning-header, header.learner-variant-header, header.site-header-desktop {
   // Set the header background color
   background-color: $header-bg;
-
-  // Set the header for desktop
-  &.site-header-desktop {
-    background-color: $header-bg;
-  }
 
   @if variable-exists(customize-header-border) {
     // Set the top and bottom border of the header


### PR DESCRIPTION
Generic header changes apply to studio headers which does not look good. 

Changes to button styles are still being applied in studio MFE's, but it looks fine.

`Private-ref`: [BB-8932](https://tasks.opencraft.com/browse/BB-8932)

<details>
  <summary>Before:</summary>

![Screenshot 2024-06-24 at 18-35-00 Schedule   details Open edX Demo Course](https://github.com/open-craft/edx-simple-theme/assets/10894099/4bcbc94f-df3c-48ef-9f01-d7d356d9dd4f)
![Screenshot 2024-06-24 at 18-34-37 Course updates Open edX Demo Course](https://github.com/open-craft/edx-simple-theme/assets/10894099/92b46210-635a-4f99-849f-0eeb9a5c8584)
![Screenshot 2024-06-24 at 18-33-51 Course outline Open edX Demo Course](https://github.com/open-craft/edx-simple-theme/assets/10894099/84d722a9-a009-4ea1-a826-3a8c7f46ff0c)
![Screenshot 2024-06-24 at 18-33-25 Course Authoring My Open edX](https://github.com/open-craft/edx-simple-theme/assets/10894099/85cdc906-3aa0-4224-b5da-808c0ce441fe)

</details> 



<details>
  <summary>After:</summary>

![Screenshot 2024-06-26 at 20-02-54 Learner Home](https://github.com/open-craft/edx-simple-theme/assets/10894099/e52da7dd-beb3-4a0f-9ea4-92220be275d5)
![Screenshot 2024-06-26 at 20-02-36 Profile My Open edX](https://github.com/open-craft/edx-simple-theme/assets/10894099/0f86ddcb-0333-4e10-8332-66b81fe3d317)
![Screenshot 2024-06-26 at 20-02-27 Account My Open edX](https://github.com/open-craft/edx-simple-theme/assets/10894099/5f5cd3ee-9c39-4128-8b25-35298c79f65e)
![Screenshot 2024-06-26 at 20-02-17 Course Open edX Demo Course My Open edX](https://github.com/open-craft/edx-simple-theme/assets/10894099/20a7bd5f-2be3-49fc-a468-86de20155970)
![Screenshot 2024-06-26 at 20-02-08 Progress Open edX Demo Course My Open edX](https://github.com/open-craft/edx-simple-theme/assets/10894099/c0529dbc-6aea-4b6c-9b84-a00c3c57f5bc)
![Screenshot 2024-06-26 at 20-01-55 Schedule   details Open edX Demo Course](https://github.com/open-craft/edx-simple-theme/assets/10894099/703e6adf-435a-4c02-aa08-45f2a582dfc8)
![Screenshot 2024-06-26 at 20-01-45 Course outline Open edX Demo Course](https://github.com/open-craft/edx-simple-theme/assets/10894099/560592e4-3c73-4440-87fd-49bf67b92cca)


</details> 