### PR TITLE
Fixes the grade removing issues in studio.

### DIFF
--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -157,3 +157,16 @@ footer.footer {
     var(--pgn-color-btn-hover-border-secondary)
   );
 }
+
+// Studio grade fixing the remove button
+.grading-scale {
+  .grading-scale-segments-and-ticks {
+    padding-top: 1.8rem !important;
+    height: 5.125rem !important;
+    border: none !important;
+  }
+
+  .btn-icon {
+    margin-top: 1.1rem;
+  }
+}


### PR DESCRIPTION
## Description

Recently we started noticing that the grade page in the studio doesn't have a way to remove grades once you add them.
This is not the default behavior and it happens only when we add custom themes to the platform.

The default behavior is:


https://github.com/user-attachments/assets/00776ed6-0105-4394-82b7-9ed4917ff1b6


What are we observing:



https://github.com/user-attachments/assets/cbce472d-dfa1-464e-b4ea-9f43ad2db423


The fix:


https://github.com/user-attachments/assets/02856b95-ae04-4c2b-ac1e-2e7c5ca2e934




Useful information to include:
-  We should add in the document/Read me of how one can make fixes and what is the right place to put what kind of information.

## Supporting information

Private-ref: [BB-9232](https://tasks.opencraft.com/browse/BB-9232)
https://github.com/open-craft/frontend-app-learning/pull/27

## Testing instructions

The instruction can get a bit complicated so I am trying to simplify it as much as possible.

I am trying to test course-authoring-mfe here since that is the mfe which is related to studio.

If you have tutor configured and running redwood:

1. Go to [studio](http://studio.local.edly.io:8001/)
2. Select any course
3. Go to "Setting" --> "Grading"  (You will find it in header)
4. Try adding grades
5. Hover over the grades in between and you will see a "Remove" button

This will prove that the functionality is working in the platform. Let's configure runtime themeing and see what happens.

1. tutor mounts add <path-to>/frontend-app-course-authoring
2. tutor images build openedx-dev
3. Once that is done `cd` into frontend-app-course-authoring and change the branch to `asu-moe/redwood-css` since the token support is available in that branch.
4. We need to edit MFE_CONFIG I have https://github.com/farhaanbukhsh/tutor-contrib-expermental-mfe to test config,  clone this and install in the virtual env of tutor.
5. Enable the plugin 'tutor plugins enable expermental-mfe'
6. `tutor dev restart  lms cms`
7. Once this is done and if you open studio you should see broken UI.
8. Now clone `https://github.com/open-craft/edx-simple-theme` and change the branch to `[artur/design-tokens-update](https://github.com/open-craft/edx-simple-theme/tree/artur/design-tokens-update)`
9. Run `npm ci` and `npm run build` inside the repo
10. `cd dist` and run `python3 -m http.server 9100`
11. Now hard refresh the studio page and it should be working fine now.
12. Try to add and remove grade as mentioned above and you shouldn't be able to.
13. Change the branch in edx-simple-theme to `farhaan/fix-grading-issue`
14. `npm run build` and restart the python server.
15. You should be able to add and remove the grade.



## Deadline

"None" if there's no rush, or provide a specific date or event (and reason) if there is one.

## Other information

@xitij2000 can I get a second opinion here from you, I want to know if this is the right way to fix it.