### PR TITLE
Add WGU customisations for removing border lines between blocks and fluid UI

### DIFF
--- a/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/lms/static/sass/partials/lms/theme/_extras.scss
@@ -5,3 +5,21 @@
 // rules into modular pieces.
 
 @import '../theme-overrides';
+
+// WGU customisations
+.course-wrapper .course-content .vert-mod .vert {
+  border-bottom: none !important;
+}
+
+
+.xmodule_display.xmodule_AboutBlock img.full-bleed,
+.xmodule_display.xmodule_CourseInfoBlock img.full-bleed,
+.xmodule_display.xmodule_HtmlBlock img.full-bleed,
+.xmodule_display.xmodule_StaticTabBlock img.full-bleed {
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
+  height: auto;
+  width: 100vw;
+  max-width: 100vw;
+}

--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -211,3 +211,9 @@ footer.footer {
     color: $link-color;
   }
 }
+
+// WGU Customisations
+.unit-container {
+  max-width: none !important;
+}
+


### PR DESCRIPTION
The theme change removes the border lines between XBlocks.  It also expands the width of the iframe with course content, allowing for a more fluid UI needed for full-bleed images. 


| Default theme with HR | This theme without HR |
|--------|--------|
| <img width="1210" height="1687" alt="view-with-hr" src="https://github.com/user-attachments/assets/b79ccea9-3bcb-4b70-b305-bababfe7802c" /> | <img width="1350" height="1773" alt="view-without-hr" src="https://github.com/user-attachments/assets/8e6049ad-ea03-49e6-bd69-1195627eb741" />|

<figure>
<img width="3448" height="3516" alt="full-bleed-image" src="https://github.com/user-attachments/assets/116221e4-1e65-45ee-9f12-78dc4a5fa976" />
<figcaption>
A full-bleed image and wider fluid UI. 
</figcaption>
</figure>



Private-ref: https://tasks.opencraft.com/browse/BB-10288