### PR TITLE
Add Cover block to full bleed spec

### DIFF
--- a/lms/static/sass/partials/lms/theme/_extras.scss
+++ b/lms/static/sass/partials/lms/theme/_extras.scss
@@ -15,7 +15,8 @@
 .xmodule_display.xmodule_AboutBlock img.full-bleed,
 .xmodule_display.xmodule_CourseInfoBlock img.full-bleed,
 .xmodule_display.xmodule_HtmlBlock img.full-bleed,
-.xmodule_display.xmodule_StaticTabBlock img.full-bleed {
+.xmodule_display.xmodule_StaticTabBlock img.full-bleed,
+.xblock-student_view-cover {
   position: relative;
   left: 50%;
   transform: translateX(-50%);


### PR DESCRIPTION
Add the cover block to the list of full bleed blocks.

## Screenshots

Before:

<img width="1699" height="946" alt="image" src="https://github.com/user-attachments/assets/8b868ecf-1199-4819-8e2d-d767b31aa750" />


After:

<img width="1699" height="946" alt="image" src="https://github.com/user-attachments/assets/842e404d-5f6a-4a29-84fd-0d17a27cbf9b" />
