### PR TITLE
Add styles/variables for two-column block

### DIFF
--- a/paragon/css/core/variables.css
+++ b/paragon/css/core/variables.css
@@ -300,6 +300,8 @@
   --pgn-typography-alert-line-height: 1.5rem;
   --pgn-typography-badge-font-size: 75%;
   --pgn-typography-btn-font-size-base: 1rem;
+  --pgn-typography-btn-font-weight: 700;
+  --pgn-typography-btn-line-height-base: 1.5;
   --pgn-typography-dropdown-item-text-decoration: none;
   --pgn-typography-image-figure-caption-font-size: 90%;
   --pgn-typography-menu-select-btn-link-text-decoration-line: underline;
@@ -541,8 +543,6 @@
   --pgn-typography-btn-font-family: var(--pgn-typography-input-btn-font-family);
   --pgn-typography-btn-font-size-sm: var(--pgn-typography-input-btn-font-size-sm);
   --pgn-typography-btn-font-size-lg: var(--pgn-typography-input-btn-font-size-lg);
-  --pgn-typography-btn-font-weight: var(--pgn-typography-font-weight-normal);
-  --pgn-typography-btn-line-height-base: var(--pgn-typography-input-btn-line-height-base);
   --pgn-typography-btn-line-height-sm: var(--pgn-typography-input-btn-line-height-sm);
   --pgn-typography-footer-text-font-size: var(--pgn-typography-font-size-xs);
   --pgn-typography-close-button-font-size: calc(var(--pgn-typography-font-size-base) * 1.5);
@@ -639,6 +639,8 @@
   --pgn-typography-form-control-file-font-family: var(--pgn-typography-form-input-font-family);
   --pgn-typography-navbar-brand-font-size: var(--pgn-typography-font-size-lg);
   --pgn-typography-navbar-toggler-font-size: var(--pgn-typography-font-size-lg);
+  --pgn-two-column-block-image-size-border-radius-lg: var(--pgn-wgu-size-border-radius-m);
+  --pgn-two-column-block-image-size-border-radius-sm: var(--pgn-wgu-size-border-radius-xs);
   --pgn-size-card-image-border-radius: var(--pgn-size-card-border-radius-base);
   --pgn-size-dropdown-border-radius-base: var(--pgn-size-border-radius-base);
   --pgn-size-form-input-height-lg: calc(var(--pgn-typography-form-input-line-height-lg) * 1em + var(--pgn-spacing-input-btn-padding-lg-y) * 2 + var(--pgn-size-form-input-height-border));

--- a/tokens/core/two-column-block.toml
+++ b/tokens/core/two-column-block.toml
@@ -1,0 +1,5 @@
+[two-column-block.image.size.border.radius.lg]
+"$value" = "{wgu.size.border.radius.m}"
+
+[two-column-block.image.size.border.radius.sm]
+"$value" = "{wgu.size.border.radius.xs}"

--- a/tokens/core/typography.toml
+++ b/tokens/core/typography.toml
@@ -27,3 +27,9 @@
 
 [typography.line-height.display.base]
 "$value" = "1.15"
+
+[typography.btn.font.weight]
+"$value" = "700"
+
+[typography.btn.line-height.base]
+"$value" = "1.5"


### PR DESCRIPTION
## Description

Add styles and variables used by the two-column block. See [opencraft/dev/exemplar-blocks!28](https://gitlab.com/opencraft/dev/exemplar-blocks/-/merge_requests/28) for how this is used.

## Testing instructions

See [opencraft/dev/exemplar-blocks!28](https://gitlab.com/opencraft/dev/exemplar-blocks/-/merge_requests/28)

## Supporting information

Private-ref: https://tasks.opencraft.com/browse/BB-10774