### PR TITLE
fix: remove 1px border from the learning mfe

### DIFF
--- a/paragon/_overrides.scss
+++ b/paragon/_overrides.scss
@@ -176,3 +176,9 @@ footer.footer {
     color: var(--pgn-color-link-base);
   }
 }
+
+// Remove 1px border from the learning mfe wrapper.
+// This overrides https://github.com/openedx/frontend-app-learning/blob/db18c2cb456fcf887b30c9122e153c163f867886/src/index.scss#L83
+.sequence-container > .sequence {
+    border: none;
+}


### PR DESCRIPTION
## Description

Remove the unwanted 1px border to the left and right of full bleed components.

## Supporting information

Private-ref: https://tasks.opencraft.com/browse/BB-10862

## Testing instructions


- use some full bleed components with this theme
- verify the 1px white border to the far left and right of the page are gone
