### PR TITLE
fix: remove spacing at the top of the page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,5 @@
 
 This theme is for applying WGU Examplar's design to Open edX. It's main focus currently is to:
 
- - Apply a full-bleed style to supported XBlocks, allowing them to display widescreen
- - Apply theming to core problem XBlock to make it fit better with the over platform style
-
-
- 
+- Apply a full-bleed style to supported XBlocks, allowing them to display widescreen
+- Apply theming to core problem XBlock to make it fit better with the over platform style

--- a/lms/static/sass/partials/lms/theme/wgu_custom.scss
+++ b/lms/static/sass/partials/lms/theme/wgu_custom.scss
@@ -109,13 +109,12 @@
   }
   input:hover,
   input:focus {
-     + label {
+    + label {
       border: none;
     }
   }
   legend {
-  	font-size: var(--pgn-typography-btn-font-size-base);
-  	
+    font-size: var(--pgn-typography-btn-font-size-base);
   }
 }
 
@@ -167,4 +166,10 @@
   &::after {
     content: "➜";
   }
+}
+
+// Remove excess padding and margins
+
+#content.content-wrapper {
+  margin-top: 0;
 }


### PR DESCRIPTION
The default comprehensive theme adds a margin at the top of the page when displaying units in an iframe in the learning MFE. This PR removes any margin or padding allowing for a seamless design. 

Private-ref: https://tasks.opencraft.com/browse/BB-10841