### PR TITLE
fix: ensures that the unit title is truncated properly and doesn't overflow

### DIFF
--- a/paragon/_exemplar.scss
+++ b/paragon/_exemplar.scss
@@ -30,6 +30,11 @@
         }
       }
     }
+    ol li div {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
     li > div.pgn_collapsible {
       margin-bottom: 0 !important;
       padding: var(--pgn-spacing-spacer-2) var(--pgn-spacing-spacer-4);


### PR DESCRIPTION
The unit titles in the dropdown/popup navigation in the header can expand beyond the size of the popup. This fixes it so they get truncated instead of overflowing. 

**Testing instructions**
- Create a section with a very long title. 
- Inside it create a subsection with a very long title. 
- Inside that create a unit with a very long title. 
- Publish and check that the navigation shows these entries a truncated. 

Note the title should be a quite long! Just write a whole sentence. 