### PR TITLE
feat: Add script to auto-redirect unit iframes to the learning MFE

### DIFF
--- a/lms/templates/head-extra.html
+++ b/lms/templates/head-extra.html
@@ -1,0 +1,14 @@
+<script>
+    (function () {
+        if (window.top === window && window.location.pathname.startsWith("/xblock")) {
+            console.log("unit iframe loaded as parent, trying to break out");
+            try {
+                const usageKey = window.location.pathname.split('/').pop();
+                const blockId = usageKey.split('block@')[1];
+                window.location.href = "/courses/" + $$course_id + "/jump_to_id/" + blockId;
+            } catch (err) {
+                console.log("Can't redirect, possibly not a unit")
+            }
+        }
+    })();
+</script>


### PR DESCRIPTION
This PR adds a script in the header to detect if the unit iframe path has been opened in the top window, and if so it will redirect back to the learning MFE. 