### PR TITLE
fix: remove top padding from unit container

### DIFF
--- a/paragon/_exemplar.scss
+++ b/paragon/_exemplar.scss
@@ -114,6 +114,10 @@ header.site-header-desktop nav button.menu-trigger {
 .unit-iframe-wrapper {
   margin-left: 0 !important;
   margin-right: 0 !important;
+  iframe {
+    /* The iframe can contain alerts which could be obscured by a low height */
+    min-height: 5rem;
+  }
 }
 
 /* The default max-width of the main container is still limited, this undoes that */

--- a/paragon/_exemplar.scss
+++ b/paragon/_exemplar.scss
@@ -104,6 +104,7 @@ header.site-header-desktop nav button.menu-trigger {
 .unit-container {
   overflow-x: auto;
   max-width: 100vw !important;
+  padding-top: 0 !important;
   @media (min-width: 576px) {
     padding-left: 0 !important;
     padding-right: 0 !important;


### PR DESCRIPTION
There are still some elements with padding that come in between the header and the XBlocks. This along with https://github.com/open-craft/edx-simple-theme/pull/73 should remove them all (hopefully)