### PR TITLE
fix: remove all top padding for seamless design

### DIFF
--- a/lms/static/sass/partials/lms/theme/wgu_custom.scss
+++ b/lms/static/sass/partials/lms/theme/wgu_custom.scss
@@ -172,4 +172,8 @@
 
 #content.content-wrapper {
   margin-top: 0;
+  padding-top: 0 !important;
+  main {
+    padding-top: 0;
+  }
 }


### PR DESCRIPTION
There are numerous elements across the learning MFE and LMS that add padding on top. This along with https://github.com/open-craft/edx-simple-theme/pull/72 should remove all of them so XBlocks can start right below the header once the other Ui modifications are in place. 