### PR TITLE
feat: spacing for quiz blocks

### DIFF
--- a/lms/static/sass/partials/lms/theme/wgu_custom.scss
+++ b/lms/static/sass/partials/lms/theme/wgu_custom.scss
@@ -18,6 +18,12 @@
   margin-bottom: 0 !important;
 }
 
+// This adds spacing back in for specific blocks, undoing the above in a targeted way.
+.xmodule_ProblemBlock {
+  padding-top: 3rem;
+  padding-bottom: 3rem;
+}
+
 // This defines full-bleed styling for images
 .xmodule_display.xmodule_AboutBlock img.full-bleed,
 .xmodule_display.xmodule_CourseInfoBlock img.full-bleed,


### PR DESCRIPTION
## Description

This PR adds spacing to the top and bottom of quiz blocks.

## Supporting information

https://tasks.opencraft.com/browse/BB-10840

## Testing instructions

**NOTE**: This is the comprehensive theme branch, not the tokens branch. Its use and activation is a bit different.

1. `cd "$(tutor config printroot)/env/build/openedx/themes/"`
2. `git clone git@github.com:open-craft/edx-simple-theme.git`
3. `cd edx-simple-theme`
4. `git checkout wgu-release/comprehensive/ulmo`
5. `tutor dev do settheme edx-simple-theme`
6. `tutor dev run watchthemes` to watch for changes and rebuild.
7. Add some space in a `.scss` file to make sure things recompile
8. Create a quiz block
9. Verify the quiz block doesn't have much of any spacing above or below it
10. `git checkout fox/quiz-spacing`
11. Wait for the styles to rebuild
12. Refresh, note the spacing above and below the quiz block.

## Deadline

ASAP